### PR TITLE
Update the correct UEFI links for Surface Duo (1st Gen)

### DIFF
--- a/Install/AOS/SurfaceDuo1.md
+++ b/Install/AOS/SurfaceDuo1.md
@@ -49,9 +49,9 @@ Here's how to acquire an FFU file with Windows 8828080 and the matching UEFI ima
 ### Surface Duo (1st Gen)
 
 UEFI files:
-- [Fast Boot](https://github.com/WOA-Project/SurfaceDuo-Releases/releases/download/2412.74/Surface.Duo.1st.Gen.UEFI-v2512.77.Fast.Boot.zip)
-- [Dual Boot for FW 2022.902.48 (Latest OTA for Surface Duo (1st Gen) devices)](https://github.com/WOA-Project/SurfaceDuo-Releases/releases/download/2412.74/Surface.Duo.1st.Gen.UEFI-v2512.77.Dual.Boot.zip)
-- [FD for making your own Dual Boot Image](https://github.com/WOA-Project/SurfaceDuo-Releases/releases/download/2412.74/Surface.Duo.1st.Gen.UEFI-v2512.77.FD.for.making.your.own.Dual.Boot.Image.zip)
+- [Fast Boot](https://github.com/WOA-Project/SurfaceDuo-Releases/releases/download/2601.12/Surface.Duo.1st.Gen.UEFI-v2601.12.Fast.Boot.zip)
+- [Dual Boot for FW 2022.902.48 (Latest OTA for Surface Duo (1st Gen) devices)](https://github.com/WOA-Project/SurfaceDuo-Releases/releases/download/2601.12/Surface.Duo.1st.Gen.UEFI-v2601.12.Dual.Boot.zip)
+- [FD for making your own Dual Boot Image](https://github.com/WOA-Project/SurfaceDuo-Releases/releases/download/2601.12/Surface.Duo.1st.Gen.UEFI-v2601.12.FD.for.making.your.own.Dual.Boot.Image.zip)
 
 [Windows 8828080 FFU File](https://fullflash.pvabel.net/DuoWOA/andromeda/)
 


### PR DESCRIPTION
the previous links were incorrect and would lead to a 404 page